### PR TITLE
refactor: headerTransparent to Platform.select

### DIFF
--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -2,6 +2,7 @@ import { getFocusedRouteNameFromRoute } from '@react-navigation/native'
 import * as Notifications from 'expo-notifications'
 import { Redirect, Stack } from 'expo-router'
 import { useEffect, useRef } from 'react'
+import { Platform } from 'react-native'
 import BackgroundFetch from 'react-native-background-fetch'
 import TrackPlayer, { Capability, Event } from 'react-native-track-player'
 import { createStyleSheet, useStyles } from 'react-native-unistyles'
@@ -114,7 +115,10 @@ export default function RootLayout() {
           headerTitleStyle: styles.title,
           headerLargeTitleStyle: styles.title,
           headerBlurEffect: 'regular',
-          headerTransparent: true,
+          headerTransparent: Platform.select({
+            ios: true,
+            android: false,
+          }),
         })}
       />
       <Stack.Screen

--- a/app/(app)/feed/group/[...feedId].tsx
+++ b/app/(app)/feed/group/[...feedId].tsx
@@ -1,4 +1,5 @@
 import { Stack, useLocalSearchParams } from 'expo-router'
+import { Platform } from 'react-native'
 import { useStyles } from 'react-native-unistyles'
 
 import { Container, Row } from '~/components'
@@ -31,7 +32,10 @@ export default function Page() {
           headerBackTitle,
           headerTitleStyle: styles.highContrastText,
           headerBlurEffect: 'regular',
-          headerTransparent: true,
+          headerTransparent: Platform.select({
+            ios: true,
+            android: false,
+          }),
           headerRight: () => (
             <Row gap={18}>
               <LoadingIndicator />


### PR DESCRIPTION
The headerBlurEffect is an iOS only option that works with headerTransparent to be set to `true`, but this will cause the header to be absolute positioned, use `Platform.select` instead

![Screenshot_20240812_200130](https://github.com/user-attachments/assets/89af365a-c89e-4686-afbe-7f61ccd82d4d)
