### PR TITLE
feat: optimize [entryId] route

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -12,6 +12,8 @@ export const users = sqliteTable('users', {
   sessionToken: text('session_token'),
 })
 
+export type User = typeof users.$inferSelect
+
 export const feeds = sqliteTable('feeds', {
   id: text('id').primaryKey(),
   url: text('url').notNull().unique(),


### PR DESCRIPTION
This PR optimizes the [entryId] route with two changes

1. Use the `dedupingInterval` option and another API `/entries/read-histories` to fetch read user and readCount instead `LazyComponent` pattern
	- Now it will revalidate `/ai/summary` in 10 minutes and `/entries/read-histories` in 2 seconds(this should be set longer maybe?).
	- Also make User schema to export its type

2. Replace `PagerView` with `FlatList` which can set the window size to render only pages in the window size range and all [VirtualizedList](https://reactnative.dev/docs/virtualizedlist#props) benefits. which also removes `LazyComponent` pattern
	- known issue: Still need to use PagerView because IDK how to make media list be a nested FlatList XD